### PR TITLE
Fix resid_pre patching

### DIFF
--- a/mechinterp/Interpreter.py
+++ b/mechinterp/Interpreter.py
@@ -103,7 +103,7 @@ class Interpreter:
             return patching.get_act_patch_block_every(self.model, corrupted_tokens, clean_cache, scoring_function)
         
         elif patching_method == PatchingMethod.ResidPre:
-            return patching.get_act_patch_resid_mid(self.model, corrupted_tokens, clean_cache, scoring_function)
+            return patching.get_act_patch_resid_pre(self.model, corrupted_tokens, clean_cache, scoring_function)
 
         elif patching_method == PatchingMethod.ResidMid:
             return patching.get_act_patch_resid_mid(self.model, corrupted_tokens, clean_cache, scoring_function)


### PR DESCRIPTION
## Summary
- use `get_act_patch_resid_pre` for `PatchingMethod.ResidPre`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6851a842da44832b9a7954b46ceff581